### PR TITLE
Request list now requires security key

### DIFF
--- a/request_list/show_requests.php
+++ b/request_list/show_requests.php
@@ -3,6 +3,14 @@
 
 include("includes/config.php");
 
+if(!isset($_GET["security_key"])){
+	die("Nope");
+}
+
+if($_GET["security_key"] != $security_key){
+	die("Nope");
+}
+
    $conn = mysqli_connect(dbhost, dbuser, dbpass, db);
    if(! $conn ) {die('Could not connect: ' . mysqli_error($conn));}
 


### PR DESCRIPTION
This fixes a security vulnerability because the security key is stored as plaintext in the javascript code on the request list. This makes it so that you must specify the security key to load the song request list. 